### PR TITLE
Pass event target.

### DIFF
--- a/thorax.js
+++ b/thorax.js
@@ -831,9 +831,10 @@
 
   function containHandlerToCurentView(handler, cid) {
     return function(event) {
+      var target = this; // this is set to event's element
       var containing_view_element = $(event.target).closest('[' + view_name_attribute_name + ']');
       if (!containing_view_element.length || containing_view_element[0].getAttribute(view_cid_attribute_name) == cid) {
-        handler(event);
+        handler(event, target);
       }
     };
   }


### PR DESCRIPTION
Typically jquery/zepto calls an event handler and sets 'this' to the
element that matches the selector from the deepest (innermost) element
so the author can say $(this) to get the matched element that triggered
the event. This is great when you use a selector like the following
$('#somediv').on('click', 'li, a', function(){}). So when user clicks on
an LI or A element within the DIV with id somediv, then the anonymous
handler mentioned will get 'this' set to the LI or A element. So where
am I going with this? It would be nice if we could pass that element
along when calling handler(event) in Thorax.

I hate to call the variable target, because event.target indicates the
deepest (innermost) element where the event occurred, and not
necessarily the element that matches the selector.

From the jQuery documentation:

If selector is omitted or is null, the event handler is referred to as
direct or directly-bound. The handler is called every time an event
occurs on the selected elements, whether it occurs directly on the
element or bubbles from a descendant (inner) element.

When a selector is provided, the event handler is referred to as
delegated. The handler is not called when the event occurs directly on
the bound element, but only for descendants (inner elements) that match
the selector. jQuery bubbles the event from the event target up to the
element where the handler is attached (i.e., innermost to outermost
element) and runs the handler for any elements along that path matching
the selector.
