### PR TITLE
Updated Quick Start instructions for starting the server.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,7 +334,7 @@
 <span class="title">thorax</span> create project-name
 <span class="title">cd</span> project-name
 <span class="title">lumbar</span> build lumbar.json public
-<span class="title">bin</span>/server <span class="number">8000</span></code></pre>
+<span class="title">npm</span> start</code></pre>
 <p>This will create a hello world project, for a more complete example clone the <a href="https://github.com/walmartlabs/thorax-todos">Thorax Todos</a> project (<a href="http://walmartlabs.github.com/thorax-todos/">demo</a>).
 
 </p>


### PR DESCRIPTION
Changed 'bin/server 8000' to 'npm start', as the bin folder is gone and 'npm start' is the way to start the server now.
