### PR TITLE
Alternative jQuery unbinding solution

### DIFF
--- a/src/helpers/view.js
+++ b/src/helpers/view.js
@@ -37,13 +37,6 @@ Thorax.View.prototype._appendViews = function(scope, callback) {
         view.ensureRendered();
       }
       $(el).replaceWith(view.el);
-      //TODO: jQuery has trouble with delegateEvents() when
-      //the child dom node is detached then re-attached
-      if (typeof jQuery !== 'undefined' && $ === jQuery) {
-        if (this._renderCount > 1) {
-          view.delegateEvents();
-        }
-      }
       callback && callback(view.el);
     }
   }, this);

--- a/src/thorax.js
+++ b/src/thorax.js
@@ -323,7 +323,8 @@ Thorax.View = Backbone.View.extend({
     if (typeof html === 'undefined') {
       return this.el.innerHTML;
     } else {
-      var element = this.$el.html(html);
+      this.el.innerHTML = "";
+      var element = this.$el.append(html);
       {{#has-plugin "helpers/view"}}
         this._appendViews();
       {{/has-plugin}}

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -175,7 +175,6 @@ $(function() {
       parent.child.$('.test').trigger('click');
       equal(callCount, 1);
       parent.render();
-      parent.child.delegateEvents();
       parent.child.$('.test').trigger('click');
       equal(callCount, 2);
       $(parent.el).remove();


### PR DESCRIPTION
A cleaner way to fix jQuery's event unbinding issue. Also fixes the spec to actually test for it.
