### PR TITLE
Prevent data objects from being loaded multiple times

### DIFF
--- a/src/data-object.js
+++ b/src/data-object.js
@@ -105,12 +105,14 @@ function bindEvents(type, target, source) {
 }
 
 function loadObject(dataObject, options) {
-  if (dataObject.load) {
+  if (!dataObject._isLoading) {
+    dataObject._isLoading = true;
     dataObject.load(function() {
+      delete dataObject._isLoading;
       options && options.success && options.success(dataObject);
+    }, function() {
+      delete dataObject._isLoading;
     }, options);
-  } else {
-    dataObject.fetch(options);
   }
 }
 


### PR DESCRIPTION
If a bound data object is already loading, don't try to load it again. Events are still bound, so for instance a view waiting on a collection `reset` event would still receive it.

We don't need to check for the existence of `object.load` anymore as we only support binding of `Thorax.Model` and `Thorax.Collection` instances.
