### PR TITLE
Make empty helper a regular helper

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -247,7 +247,7 @@ Thorax.View.on({
 });
 
 function onCollectionReset(collection) {
-  if (!collection || (collection === this.collection && this._objectOptionsByCid[this.collection.cid].render)) {
+  if (!collection || (this.collection && collection === this.collection && this._objectOptionsByCid[this.collection.cid].render)) {
     this.renderCollection();
   }
 }

--- a/test/src/helpers/collection.js
+++ b/test/src/helpers/collection.js
@@ -45,7 +45,7 @@ describe('collection helper', function() {
     function testNesting(view, msg) {
       var blogModel = new Thorax.Model();
       view.setModel(blogModel);
-      expect(view.$('[data-view-helper]').html()).to.equal('empty', msg + ' : starts empty');
+      expect(view.html()).to.equal('empty', msg + ' : starts empty');
       var authors = [
         new Thorax.Model({author: 'author 1'}),
         new Thorax.Model({author: 'author 2'})

--- a/test/src/helpers/empty.js
+++ b/test/src/helpers/empty.js
@@ -14,7 +14,7 @@ describe('empty helper', function() {
       template: '{{#empty}}empty{{else}}not empty{{/empty}}'
     });
     emptyView.render();
-    expect(emptyView.$('[data-view-helper]').html()).to.equal('empty');
+    expect(emptyView.html()).to.equal('empty');
   });
   it('should render empty with an empty model', function() {
     var emptyModelView = new Thorax.View({
@@ -22,18 +22,18 @@ describe('empty helper', function() {
       model: new Thorax.Model()
     });
     emptyModelView.render();
-    expect(emptyModelView.$('[data-view-helper]').html()).to.equal('empty');
+    expect(emptyModelView.html()).to.equal('empty');
     emptyModelView.model.set({foo: 'value'});
-    expect(emptyModelView.$('[data-view-helper]').html()).to.equal('not empty');
+    expect(emptyModelView.html()).to.equal('not empty');
   });
   it('should render when model is added', function() {
     var emptyModelView = new Thorax.View({
       template: '{{#empty}}empty{{else}}not empty{{/empty}}'
     });
     emptyModelView.render();
-    expect(emptyModelView.$('[data-view-helper]').html()).to.equal('empty');
+    expect(emptyModelView.html()).to.equal('empty');
     emptyModelView.setModel(new Thorax.Model({foo: 'value'}));
-    expect(emptyModelView.$('[data-view-helper]').html()).to.equal('not empty');
+    expect(emptyModelView.html()).to.equal('not empty');
   });
   it('should render empty with collection parameter', function() {
     var emptyCollectionView = new Thorax.View({
@@ -41,12 +41,12 @@ describe('empty helper', function() {
       myCollection: new Thorax.Collection()
     });
     emptyCollectionView.render();
-    expect(emptyCollectionView.$('[data-view-helper]').html()).to.equal('empty');
+    expect(emptyCollectionView.html()).to.equal('empty');
     var model = new Thorax.Model();
     emptyCollectionView.myCollection.add(model);
-    expect(emptyCollectionView.$('[data-view-helper]').html()).to.equal('not empty');
+    expect(emptyCollectionView.html()).to.equal('not empty');
     emptyCollectionView.myCollection.remove(model);
-    expect(emptyCollectionView.$('[data-view-helper]').html()).to.equal('empty');
+    expect(emptyCollectionView.html()).to.equal('empty');
   });
 
   it('empty and collection helpers in the same template', function() {
@@ -55,13 +55,10 @@ describe('empty helper', function() {
       letters: new Thorax.Collection()
     });
     a.render();
-    var oldRenderCount = a._renderCount;
     expect(a.$('.empty').html()).to.equal('empty');
-    a.letters.reset(letterCollection.models);
+    a.letters.reset(_.clone(letterCollection.models));
     expect(a.$('.empty').length).to.equal(0);
     expect(a.$('[data-collection-cid] div')[0].innerHTML).to.equal('a');
-    expect(oldRenderCount).to.equal(a._renderCount, 'render count unchanged on collection reset');
-
     var b = new Thorax.View({
       template: '{{#empty letters}}<div class="empty">empty a</div>{{/empty}}{{#collection letters}}{{letter}}{{else}}empty b{{/collection}}',
       letters: new Thorax.Collection()

--- a/test/src/helpers/view.js
+++ b/test/src/helpers/view.js
@@ -227,13 +227,13 @@ describe('view helper', function() {
   it("views embedded with view helper do not incorrectly set parent", function() {
     var view = new Thorax.View({
       child: new Thorax.View({
-        template: '{{#empty}}so empty{{/empty}}'
+        template: '{{#loading}}loading{{/loading}}'
       }),
       template: '{{view child}}'
     });
     view.render();
     var emptyView = _.find(view.child.children, function(child) {
-      return child._helperName === 'empty';
+      return child._helperName === 'loading';
     });
     expect(emptyView.parent).to.equal(view.child);
 
@@ -242,11 +242,11 @@ describe('view helper', function() {
       child: new Thorax.View({
         template: ''
       }),
-      template: '{{#view child}}{{#empty}}so empty{{/empty}}{{/view}}'
+      template: '{{#view child}}{{#loading}}loading{{/loading}}{{/view}}'
     });
     view.render();
     emptyView = _.find(view.child.children, function(child) {
-      return child._helperName === 'empty';
+      return child._helperName === 'loading';
     });
     expect(emptyView.parent).to.equal(view.child);
   });


### PR DESCRIPTION
Makes it a regular helper vs. a helper that generates a `HelperView`. Will no longer generate any HTML on it's own or accept tag arguments like `class`, `id`, `tag`.
