### PR TITLE
Make loading helper a regular helper

### DIFF
--- a/src/helpers/loading.js
+++ b/src/helpers/loading.js
@@ -1,17 +1,10 @@
-Handlebars.registerViewHelper('loading', function(view) {
-  var _render = view.render;
-  view.render = function() {
-    if (view.parent.$el.hasClass(view.parent._loadingClassName)) {
-      return _render.call(this, view.fn);
-    } else {
-      return _render.call(this, view.inverse);
-    }
-  };
-  var callback = _.bind(view.render, view);
-  view.parent._loadingCallbacks = view.parent._loadingCallbacks || [];
-  view.parent._loadingCallbacks.push(callback);
-  view.on('destroyed', function() {
-    view.parent._loadingCallbacks = _.without(view.parent._loadingCallbacks, callback);
-  });
-  view.render();
+Handlebars.registerHelper('loading', function(options) {
+  var view = getOptionsData(options).view;
+  view.off('change:load-state', onLoadStateChange, view);
+  view.on('change:load-state', onLoadStateChange, view);
+  return view._isLoading ? options.fn(this) : options.inverse(this);
 });
+
+function onLoadStateChange() {
+  this.render();
+}

--- a/src/loading.js
+++ b/src/loading.js
@@ -153,13 +153,10 @@ Thorax.mixinLoadable = function(target, useParent) {
       if (!that.nonBlockingLoad && !background && rootObject && rootObject !== this) {
         rootObject.trigger(loadStart, message, background, object);
       }
+      that._isLoading = true;
       $(that.el).addClass(that._loadingClassName);
-      //used by loading helpers
-      if (that._loadingCallbacks) {
-        _.each(that._loadingCallbacks, function(callback) {
-          callback();
-        });
-      }
+      // used by loading helpers
+      that.trigger('change:load-state', 'start');
     },
     onLoadEnd: function(/* background, object */) {
       var that = useParent ? this.parent : this;
@@ -168,14 +165,11 @@ Thorax.mixinLoadable = function(target, useParent) {
       if (!that || !that.el) {
         return;
       }
-
+      
+      that._isLoading = false;
       $(that.el).removeClass(that._loadingClassName);
-      //used by loading helpers
-      if (that._loadingCallbacks) {
-        _.each(that._loadingCallbacks, function(callback) {
-          callback();
-        });
-      }
+      // used by loading helper
+      that.trigger('change:load-state', 'end');
     }
   });
 };

--- a/test/src/helpers/view.js
+++ b/test/src/helpers/view.js
@@ -227,26 +227,28 @@ describe('view helper', function() {
   it("views embedded with view helper do not incorrectly set parent", function() {
     var view = new Thorax.View({
       child: new Thorax.View({
-        template: '{{#loading}}loading{{/loading}}'
+        template: '{{#collection}}{{/collection}}'
       }),
-      template: '{{view child}}'
+      template: '{{view child}}',
+      collection: new Thorax.Collection()
     });
     view.render();
-    var emptyView = _.find(view.child.children, function(child) {
-      return child._helperName === 'loading';
+    var collectionView = _.find(view.child.children, function(child) {
+      return child._helperName === 'collection';
     });
-    expect(emptyView.parent).to.equal(view.child);
+    expect(collectionView.parent).to.equal(view.child);
 
     // ensure overrides do not modify either
     view = new Thorax.View({
       child: new Thorax.View({
         template: ''
       }),
-      template: '{{#view child}}{{#loading}}loading{{/loading}}{{/view}}'
+      template: '{{#view child}}{{#collection}}{{/collection}}{{/view}}',
+      collection: new Thorax.Collection()
     });
     view.render();
     emptyView = _.find(view.child.children, function(child) {
-      return child._helperName === 'loading';
+      return child._helperName === 'collection';
     });
     expect(emptyView.parent).to.equal(view.child);
   });


### PR DESCRIPTION
For symmetry with the new `empty` implementation. Bonus: it's also smaller and less complicated.
