### PR TITLE
Native indexOf breaks internet explorer.

### DIFF
--- a/src/loading.js
+++ b/src/loading.js
@@ -56,7 +56,7 @@ Thorax.loadHandler = function(start, end, context) {
 
     // Prevent binds to the same object multiple times as this can cause very bad things
     // to happen for the load;load;end;end execution flow.
-    if (loadInfo.events.indexOf(object) >= 0) {
+    if (_.indexOf(loadInfo.events, object) >= 0) {
       loadInfo.events.push(object);
       return;
     }
@@ -71,11 +71,11 @@ Thorax.loadHandler = function(start, end, context) {
       }
 
       var events = loadInfo.events,
-          index = events.indexOf(object);
+          index = _.indexOf(events, object);
       if (index >= 0) {
         events.splice(index, 1);
 
-        if (events.indexOf(object) < 0) {
+        if (_.indexOf(events, object) < 0) {
           // Last callback for this particlar object, remove the bind
           object.off(loadEnd, endCallback);
         }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -23,7 +23,7 @@ Thorax.View.prototype.mixin = function(name) {
   if (!this._appliedMixins) {
     this._appliedMixins = [];
   }
-  if (this._appliedMixins.indexOf(name) === -1) {
+  if (_.indexOf(this._appliedMixins, name) === 1) {
     this._appliedMixins.push(name);
     if (_.isFunction(name)) {
       name.call(this);

--- a/src/util.js
+++ b/src/util.js
@@ -13,7 +13,7 @@ function createRegistryWrapper(klass, hash) {
 function registryGet(object, type, name, ignoreErrors) {
   var target = object[type],
       value;
-  if (name.indexOf('.') >= 0) {
+  if (_.indexOf(name, '.') >= 0) {
     var bits = name.split(/\./);
     name = bits.pop();
     _.each(bits, function(key) {


### PR DESCRIPTION
Replaced usage of native indexOf with it's underscore alternative, so that IE7 and IE8 work.
