### PR TITLE
Fix bug where mixins could never be included

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -23,7 +23,7 @@ Thorax.View.prototype.mixin = function(name) {
   if (!this._appliedMixins) {
     this._appliedMixins = [];
   }
-  if (_.indexOf(this._appliedMixins, name) === 1) {
+  if (_.indexOf(this._appliedMixins, name) === -1) {
     this._appliedMixins.push(name);
     if (_.isFunction(name)) {
       name.call(this);


### PR DESCRIPTION
Mixins could never be included because `mixin` method was accidentally checking for `1` instead of `-1` and so would never be true and never include a mixin.
