### PR TITLE
Safe guard against additional ready event triggers.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
   "bitwise": true,
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "forin": true,
   "immed": false,
   "latedef": false,

--- a/src/event.js
+++ b/src/event.js
@@ -120,7 +120,7 @@ Thorax.View.on('ready', function(options) {
   if (!this._isReady) {
     this._isReady = true;
     function triggerReadyOnChild(child) {
-      child.trigger('ready', options);
+      child._isReady || child.trigger('ready', options);
     }
     _.each(this.children, triggerReadyOnChild);
     this.on('child', triggerReadyOnChild);

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,3 +1,4 @@
+/*global getOptionsData, normalizeHTMLAttributeOptions*/
 var layoutCidAttributeName = 'data-layout-cid';
 
 Thorax.LayoutView = Thorax.View.extend({
@@ -44,9 +45,9 @@ Thorax.LayoutView = Thorax.View.extend({
     if (view) {
       triggerLifecycleEvent.call(this, 'activated', options);
       view.trigger('activated', options);
-      this._addChild(view);
       this._view = view;
       this._view.appendTo(getLayoutViewsTargetElement.call(this));
+      this._addChild(view);
     } else {
       this._view = undefined;
     }

--- a/src/thorax.js
+++ b/src/thorax.js
@@ -1,4 +1,4 @@
-/*global cloneInheritVars, createInheritVars, createRegistryWrapper, getValue, inheritVars */
+/*global cloneInheritVars, createInheritVars, resetInheritVars, createRegistryWrapper, getValue, inheritVars */
 
 //support zepto.forEach on jQuery
 if (!$.fn.forEach) {
@@ -34,7 +34,7 @@ var Thorax = this.Thorax = {
     throw err;
   },
   //deprecated, here to ensure existing projects aren't mucked with
-  templates: Handlebars.templates 
+  templates: Handlebars.templates
 };
 
 Thorax.View = Backbone.View.extend({

--- a/test/src/event.js
+++ b/test/src/event.js
@@ -248,6 +248,21 @@ describe('event', function() {
     expect(spy.callCount).to.equal(1);
   });
 
+  it('should trigger ready event on layout view', function() {
+    var spy = this.spy(),
+        layoutView = new Thorax.LayoutView(),
+        view = new Thorax.View({
+          events: {
+            ready: spy
+          },
+          template: function() {}
+        });
+    expect(spy.callCount).to.equal(0, 'ready event will trigger via LayoutView');
+    layoutView.appendTo(document.body);
+    layoutView.setView(view);
+    expect(spy.callCount).to.equal(1, 'ready event will trigger via LayoutView');
+  });
+
   it("should trigger ready event on children", function() {
     var spy = this.spy(),
         layoutView = new Thorax.LayoutView(),
@@ -318,7 +333,7 @@ describe('event', function() {
       expect(spy).to.have.been.calledOnce;
     });
     it('should cleanup backbone events on destroy', function() {
-      var spy = this.spy()
+      var spy = this.spy(),
           view = new Thorax.View({
             events: {
               model: {


### PR DESCRIPTION
The ready event was triggering twice in a row when using `setView` via a LayoutView. Just added a safeguard to the event check since `appendTo` also triggers it's own ready events. Also moved the call to `_addChild` below the `appendTo` call since it makes more sense to me for the `ready` event to be triggered after the child is attached to the DOM.

Should fix #157 and has the test case attached.

There are also some other small fixes for JSHint and one of the test cases was missing a comma. 
