### PR TITLE
Fix handle click not being called on the link button helper.

### DIFF
--- a/src/helpers/button-link.js
+++ b/src/helpers/button-link.js
@@ -44,14 +44,14 @@ Handlebars.registerHelper('link', function() {
 var clickSelector = '[' + callMethodAttributeName + '], [' + triggerEventAttributeName + ']';
 
 function handleClick(event) {
-  var target = $(event.target),
-      view = target.view({helper: false}),
-      methodName = target.attr(callMethodAttributeName),
-      eventName = target.attr(triggerEventAttributeName),
+  var $this = $(this),
+      view = $this.view({helper: false}),
+      methodName = $this.attr(callMethodAttributeName),
+      eventName = $this.attr(triggerEventAttributeName),
       methodResponse = false;
   methodName && (methodResponse = view[methodName].call(view, event));
   eventName && view.trigger(eventName, event);
-  target.tagName === "A" && methodResponse === false && event.preventDefault();
+  this.tagName === 'A' && methodResponse === false && event.preventDefault();
 }
 
 var lastClickHandlerEventName;

--- a/test/src/helpers/button-link.js
+++ b/test/src/helpers/button-link.js
@@ -74,4 +74,21 @@ describe('button-link helpers', function() {
     expect(view.$('a').html()).to.equal('content');
     expect(view.$('a').attr('href')).to.equal('#href');
   });
+
+  it('nested prevent default', function (done) {
+    var spy = this.spy(),
+        view = new Thorax.View({
+          template: Handlebars.compile('{{#link "test"}}<span>text</span>{{/link}}')
+        });
+    // Make sure that hash change is only triggered once
+    $(document).on('click.test.prevent-default', function (e) {
+      expect(e.isDefaultPrevented()).to.equal(true);
+      done();
+    });
+    // Append the view to the body for testing
+    view.appendTo(document.body);
+    view.$('a span').trigger('click');
+    view.$el.remove();
+    $(document).off('click.test.prevent-default');
+  });
 });


### PR DESCRIPTION
Fixes #143. Added a working test case. Basically uses `event.currentTarget` instead of the `event.target` which is where the event originated from.
