### PR TITLE
View render now keeps track of user input

### DIFF
--- a/src/thorax.js
+++ b/src/thorax.js
@@ -149,9 +149,10 @@ Thorax.View = Backbone.View.extend({
     });
     this.children = children;
 
+    this.trigger('before:rendered');
     this._rendering = true;
 
-    try{
+    try {
       if (_.isUndefined(output) || (!_.isElement(output) && !Thorax.Util.is$(output) && !(output && output.el) && !_.isString(output) && !_.isFunction(output))) {
         // try one more time to assign the template, if we don't
         // yet have one we must raise
@@ -175,8 +176,10 @@ Thorax.View = Backbone.View.extend({
 
     //accept a view, string, Handlebars.SafeString or DOM element
     this.html((output && output.el) || (output && output.string) || output);
+
     ++this._renderCount;
     this.trigger('rendered');
+
     return output;
   },
 


### PR DESCRIPTION
Working on fixing #114.

This updates the render function to keep track of input data when populate and render has previously been called. Blocks both the `populate` and `serialize` events from emitting while the view is rendering (though this could be an option passed in if that fits better). 

The current behaviour for this PR is for the form data to be serialised and filtered for non-empty inputs. This is then merged with the current model state which allows new properties to be defined on the model and render to add the extra property to the form. Also moves the end rendering flag to below the input populating.

Not sure about the merging behaviour, doesn't seem to fit properly. Thinking that either we should just use the user data without merging new data - or that populate should be update to serialise and merge when no attributes are passed in. Any suggestions?
