### PR TITLE
Cast an array as a collection if passed to setCollection

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -45,6 +45,9 @@ Thorax.Collections = {};
 createRegistryWrapper(Thorax.Collection, Thorax.Collections);
 
 dataObject('collection', {
+  cast: function(collection) {
+    return _.isArray(collection) ? new Thorax.Collection(collection) : collection;
+  },
   set: 'setCollection',
   bindCallback: onSetCollection,
   defaultOptions: {

--- a/src/data-object.js
+++ b/src/data-object.js
@@ -18,6 +18,10 @@ function dataObject(type, spec) {
   };
 
   function setObject(dataObject, options) {
+    if (spec.cast) {
+      dataObject = spec.cast(dataObject);
+    }
+
     var old = this[type],
         $el = getValue(this, spec.$el);
 

--- a/test/src/helpers/collection.js
+++ b/test/src/helpers/collection.js
@@ -241,6 +241,22 @@ describe('collection helper', function() {
     testNesting(view, 'nested inline');
   });
 
+  it('should create collection from vanilla array', function() {
+    var view = new Thorax.View({
+      collection: [{key: 'value'}],
+      template: Handlebars.compile('{{#collection tag="ul"}}<li>{{key}}</li>{{/collection}}')
+    });
+    view.render();
+    expect(view.$('ul li').html()).to.equal('value');
+
+    view = new Thorax.View({
+      list: [{key: 'value'}],
+      template: Handlebars.compile('{{#collection list tag="ul"}}<li>{{key}}</li>{{/collection}}')
+    });
+    view.render();
+    expect(view.$('ul li').html()).to.equal('value');
+  });
+
   describe('delgation', function() {
     var view,
         spy;


### PR DESCRIPTION
Use case is when deep nesting collections from server data is a PITA to have to go setup parse to make collections manually. Don't feel this needs to be documented as it will not modify your data structure and will just work without modifying existing behavior.
