### PR TITLE
Better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,3 +1159,41 @@ Bound DOM event handlers in Thorax are wrapped with a try / catch block, calling
     };
 
 Override this function with your own logging / debugging handler. `name` will be the event name where the error was thrown.
+
+# Error Codes
+
+## button-trigger
+
+`button` helper must have a method name as the first argument or a 'trigger', or a 'method' attribute specified.
+
+## link-href
+
+`link` helper requires an href as the first argument or an `href` attribute.
+
+## collection-element-helper
+
+`collection-element` helper must be declared inside of a `CollectionView`
+
+## super-parent
+
+Cannot use `super` helper when parent has no name or template.
+
+## view-helper-hash-args
+
+Hash arguments are not allowed in the `view` helper as templates should not introduce side effects to view instances.
+
+## layout-element-helper
+
+`layout-element` helper must be used within a `LayoutView`.
+
+## mixed-fetch
+
+Both `set` and `reset` were passed to `fetch`, must use one or the other.
+
+## nested-render
+
+`render` was called which triggered an event handler which in turn called `render`. Infinite recursion was halted.
+
+## handlebars-no-data
+
+Handlebars template compiled without data, use: Handlebars.compile(template, {data: true})

--- a/src/helpers/button-link.js
+++ b/src/helpers/button-link.js
@@ -1,3 +1,5 @@
+/* global createErrorMessage */
+
 var callMethodAttributeName = 'data-call-method',
     triggerEventAttributeName = 'data-trigger-event';
 
@@ -10,7 +12,7 @@ Handlebars.registerHelper('button', function(method, options) {
       expandTokens = hash['expand-tokens'];
   delete hash['expand-tokens'];
   if (!method && !options.hash.trigger) {
-    throw new Error("button helper must have a method name as the first argument or a 'trigger', or a 'method' attribute specified.");
+    throw new Error(createErrorMessage('button-trigger'));
   }
   normalizeHTMLAttributeOptions(hash);
   hash.tagName = hash.tagName || 'button';
@@ -29,7 +31,7 @@ Handlebars.registerHelper('link', function() {
       expandTokens = hash['expand-tokens'];
   delete hash['expand-tokens'];
   if (!url[0] && url[0] !== '') {
-    throw new Error("link helper requires an href as the first argument or an 'href' attribute");
+    throw new Error(createErrorMessage('link-href'));
   }
   normalizeHTMLAttributeOptions(hash);
   url.push(options);

--- a/src/helpers/collection.js
+++ b/src/helpers/collection.js
@@ -1,3 +1,5 @@
+/* global createErrorMessage */
+
 Thorax.CollectionHelperView = Thorax.CollectionView.extend({
   // Forward render events to the parent
   events: {
@@ -143,7 +145,7 @@ Handlebars.registerViewHelper('collection', Thorax.CollectionHelperView, functio
 
 Handlebars.registerHelper('collection-element', function(options) {
   if (!getOptionsData(options).view.renderCollection) {
-    throw new Error("collection-element helper must be declared inside of a CollectionView");
+    throw new Error(createErrorMessage('collection-element-helper'));
   }
   var hash = options.hash;
   normalizeHTMLAttributeOptions(hash);

--- a/src/helpers/super.js
+++ b/src/helpers/super.js
@@ -1,3 +1,5 @@
+/* global createErrorMessage */
+
 Handlebars.registerHelper('super', function(options) {
   var declaringView = getOptionsData(options).view,
       parent = declaringView.constructor && declaringView.constructor.__super__;
@@ -5,7 +7,7 @@ Handlebars.registerHelper('super', function(options) {
     var template = parent.template;
     if (!template) {
       if (!parent.name) {
-        throw new Error('Cannot use super helper when parent has no name or template.');
+        throw new Error(createErrorMessage('super-parent'));
       }
       template = parent.name;
     }

--- a/src/helpers/view.js
+++ b/src/helpers/view.js
@@ -1,4 +1,4 @@
-/*global viewTemplateOverrides */
+/*global viewTemplateOverrides, createErrorMessage */
 Handlebars.registerViewHelper('view', {
   factory: function(args, options) {
     var View = args.length >= 1 ? args[0] : Thorax.View;
@@ -14,7 +14,7 @@ Handlebars.registerViewHelper('view', {
         options = instance._helperOptions.options,
         placeholderId = instance.cid;
     if (options.hash && _.keys(options.hash).length > 0) {
-      throw new Error("Hash arguments are not allowed in the view helper as templates should not introduce side effects to view instances.");
+      throw new Error(createErrorMessage('view-helper-hash-args'));
     }
     if (options.fn) {
       viewTemplateOverrides[placeholderId] = options.fn;

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,4 +1,4 @@
-/*global getOptionsData, normalizeHTMLAttributeOptions*/
+/*global getOptionsData, normalizeHTMLAttributeOptions, createErrorMessage */
 var layoutCidAttributeName = 'data-layout-cid';
 
 Thorax.LayoutView = Thorax.View.extend({
@@ -57,7 +57,7 @@ Handlebars.registerHelper('layout-element', function(options) {
   var view = getOptionsData(options).view;
   // duck type check for LayoutView
   if (!view.getView) {
-    throw new Error('layout-element must be used within a LayoutView');
+    throw new Error(createErrorMessage('layout-element-helper'));
   }
   options.hash[layoutCidAttributeName] = view.cid;
   normalizeHTMLAttributeOptions(options.hash);

--- a/src/loading.js
+++ b/src/loading.js
@@ -1,4 +1,4 @@
-/*global collectionOptionNames, inheritVars */
+/*global collectionOptionNames, inheritVars, createErrorMessage */
 
 var loadStart = 'load:start',
     loadEnd = 'load:end',
@@ -301,7 +301,7 @@ function fetchQueue(options, $super) {
     var reset = (this.fetchQueue[0] || {}).reset;
     if (reset !== options.reset) {
       // fetch with concurrent set & reset not allowed
-      throw new Error('mixed-fetch');
+      throw new Error(createErrorMessage('mixed-fetch'));
     }
   }
 

--- a/src/thorax.js
+++ b/src/thorax.js
@@ -1,4 +1,4 @@
-/*global cloneInheritVars, createInheritVars, resetInheritVars, createRegistryWrapper, getValue, inheritVars */
+/*global cloneInheritVars, createInheritVars, resetInheritVars, createRegistryWrapper, getValue, inheritVars, createErrorMessage */
 
 //support zepto.forEach on jQuery
 if (!$.fn.forEach) {
@@ -146,7 +146,7 @@ Thorax.View = Backbone.View.extend({
       // execution. If in a situation where you need to rerender in response to an event that is
       // triggered sync in the rendering lifecycle it's recommended to defer the subsequent render
       // or refactor so that all preconditions are known prior to exec.
-      throw new Error('nested-render');
+      throw new Error(createErrorMessage('nested-render'));
     }
 
     this._previousHelpers = _.filter(this.children, function(child) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,8 @@
 /*global createRegistryWrapper:true, cloneEvents: true */
+function createErrorMessage(code) {
+  return 'Error "' + code + '". For more information visit http://thoraxjs.org/error-codes' + '#' + code;
+}
+
 function createRegistryWrapper(klass, hash) {
   var $super = klass.extend;
   klass.extend = function() {
@@ -186,7 +190,7 @@ function addEvents(target, source, context, listenToObject) {
 
 function getOptionsData(options) {
   if (!options || !options.data) {
-    throw new Error('Handlebars template compiled without data, use: Handlebars.compile(template, {data: true})');
+    throw new Error(createErrorMessage('handlebars-no-data'));
   }
   return options.data;
 }


### PR DESCRIPTION
Move explanations to README (which in turn will generate a page on the site) and add a url in the error messages to the relevant docs.
