### PR TITLE
support dom bindings when added in View.initialize

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -60,7 +60,7 @@ _.extend(Thorax.View.prototype, {
       //accept on("click a", callback, context)
       _.each((_.isArray(callback) ? callback : [callback]), function(callback) {
         var params = eventParamsFromEventItem.call(this, eventName, callback, context || this);
-        if (params.type === 'DOM' && !this.$el) {
+        if (params.type === 'DOM' && !this._eventsDelegated) {
           //will call _addEvent during delegateEvents()
           if (!this._eventsToDelegate) {
             this._eventsToDelegate = [];
@@ -83,6 +83,7 @@ _.extend(Thorax.View.prototype, {
       this.on(events);
     }
     this._eventsToDelegate && _.each(this._eventsToDelegate, this._addEvent, this);
+    this._eventsDelegated = true;
   },
   //params may contain:
   //- name

--- a/test/src/event.js
+++ b/test/src/event.js
@@ -248,6 +248,30 @@ describe('event', function() {
     expect(spy.callCount).to.equal(1);
   });
 
+  it("on works after _ensureElement but before delegateEvents (basically initialize)", function() {
+    // this is useful for mixins for example
+    var spy = this.spy();
+    var TestView = Thorax.View.extend({
+      initialize: function() {
+        this.on({
+          'click button': spy
+        });
+      },
+      template: function() {
+        return '<button>foo</button>';
+      }
+    });
+
+    var view = new TestView();
+    view.render();
+    var el = view.$('button');
+    expect(el.length).to.equal(1);
+    $(document.body).append(view.$el);
+    el.trigger('click');
+    view.$el.remove();
+    expect(spy.callCount).to.equal(1);
+  });
+
   it('should trigger ready event on layout view', function() {
     var spy = this.spy(),
         layoutView = new Thorax.LayoutView(),


### PR DESCRIPTION
Currently DOM bindings will not work because $el is used to determine if eventsToDelegate should be populated or _addEvent should be called.  The problem is that, during initialize, $el has been created but delegateEvents has not yet been called.

https://github.com/jashkenas/backbone/blob/master/backbone.js#L996
