### PR TITLE
View.bind and View.on have different behavior

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -112,6 +112,8 @@ _.extend(Thorax.View.prototype, {
   }
 });
 
+Thorax.View.prototype.bind = Thorax.View.prototype.on;
+
 // When view is ready trigger ready event on all
 // children that are present, then register an
 // event that will trigger ready on new children


### PR DESCRIPTION
bind: Behaves exactly as Backbone.View.bind
on: Has thorax extensions.

The distinction in the behavior is confusing as they perform identically on every other platform.
