### PR TITLE
add a view event that will force refresh collection views

### DIFF
--- a/src/helpers/collection.js
+++ b/src/helpers/collection.js
@@ -139,6 +139,9 @@ Handlebars.registerViewHelper('collection', Thorax.CollectionHelperView, functio
         view.setCollection(dataObject);
       }
     });
+    view.parent.on('collection:refresh', function() {
+      view.renderCollection();
+    })
   }
   collection && view.setCollection(collection);
 });

--- a/test/src/helpers/collection.js
+++ b/test/src/helpers/collection.js
@@ -5,6 +5,19 @@ describe('collection helper', function() {
     expect(Handlebars.VM.noop).to.exist;
   });
 
+  it('should obey collection:refresh event', function() {
+    var view = new Thorax.View({
+      key: 'value',
+      template: Handlebars.compile('{{#collection class="{{key}}" expand-tokens=true}}{{/collection}}'),
+      collection: new Thorax.Collection([{a: 'a'}])
+    });
+    view.render();
+    var spy = this.spy();
+    view.on('rendered:collection', spy);
+    view.trigger('collection:refresh');
+    expect(spy).to.have.been.calledOnce;
+  });
+
   it('should allow use of expand-tokens', function() {
     var view = new Thorax.View({
       key: 'value',
@@ -14,7 +27,7 @@ describe('collection helper', function() {
     view.render();
     expect(view.$('div.value').length).to.equal(1);
   });
-  
+
   it('should allow arbitrary html attributes', function() {
     var view = new Thorax.View({
       template: Handlebars.compile('{{#collection random="value"}}{{/collection}}'),


### PR DESCRIPTION
The problem currently exists that CollectionView instances created by the collection view helper aren't convienant to access.  This provides a 1 liner to force collections to refresh.
