### PR TITLE
Honor the options.root scope

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -236,7 +236,7 @@ function onErrorOrInvalidData () {
 function eachNamedInput(view, options, iterator) {
   var i = 0;
 
-  view.$('select,input,textarea', options.root || view.el).each(function() {
+  $('select,input,textarea', options.root || view.el).each(function() {
     if (!options.children) {
       if (view !== $(this).view({helper: false})) {
         return;


### PR DESCRIPTION
If we use view.$, then backbone will run queries scoped on the view. So
basically if you pass in an optional scope, say with options.root, then
it will just ignore it. However if you revert to $ than the options.root
scope will once again be honored. Take a look at the backbone source
[here](https://github.com/jashkenas/backbone/blob/1.0.0/backbone.js#L1006).
