### PR TITLE
load:end only fired if sync invokes complete callback

### DIFF
--- a/src/loading.js
+++ b/src/loading.js
@@ -369,14 +369,22 @@ _.each(klasses, function(DataClass) {
         }
       }
 
-      var self = this,
-          complete = options.complete;
+      if (!options.loadTriggered) {
+        var self = this;
 
-      options.complete = function() {
-        complete && complete.apply(this, arguments);
-        self.loadEnd();
-      };
-      self.loadStart(undefined, options.background);
+        function endWrapper(method) {
+          var $super = options[method];
+          options[method] = function() {
+            self.loadEnd();
+            $super && $super.apply(this, arguments);
+          };
+        }
+
+        endWrapper('success');
+        endWrapper('error');
+        self.loadStart(undefined, options.background);
+      }
+
       return fetchQueue.call(this, options || {}, $fetch);
     },
 

--- a/test/src/loading.js
+++ b/test/src/loading.js
@@ -9,7 +9,7 @@ describe('loading', function() {
 
   Thorax.setRootObject(Application);
 
-  describe('fetch set/reset test', function() {
+  describe('fetch', function() {
     var colData = [{id: 1, name: "foo"}, {id: 2, name: "bar"}],
         C = Thorax.Collection.extend({
           url: 'foo'
@@ -35,6 +35,32 @@ describe('loading', function() {
         exc = e;
       }
       expect(exc).to.not.eql(undefined);
+    });
+    it('views should emit load events', function() {
+      var startSpy = this.spy(),
+          endSpy = this.spy();
+
+      c.on('load:start', startSpy);
+      c.on('load:end', endSpy);
+
+      c.fetch();
+      this.requests[0].respond(200, {}, '[]');
+
+      expect(startSpy).to.have.been.calledOnce;
+      expect(endSpy).to.have.been.calledOnce;
+    });
+    it('views should not emit load events if triggered flag is set', function() {
+      var startSpy = this.spy(),
+          endSpy = this.spy();
+
+      c.on('load:start', startSpy);
+      c.on('load:end', endSpy);
+
+      c.fetch({loadTriggered: true});
+      this.requests[0].respond(200, {}, '[]');
+
+      expect(startSpy).to.not.have.been.called;
+      expect(endSpy).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
Hi!

The way the loading mixins are put together is giving me just a touch of grief when it comes to _non_-remote/AJAX loading of models and collections.

I'm using a data adapter that sometimes opts to load model and collection data out of `localStorage` instead of passing on to `$.ajax` (Zepto in my case). I'm running into some difficulty because `load:start` _always_ fires from `setModel` (etc.) but `load:end` will _only_ fire if the `options.complete` callback is invoked.

`options.complete` will only get invoked if the sync is a remote one and using `$.ajax` (`options.complete` is an AJAX option for Zepto or jQuery `$.ajax`, which is probably just restating what you already know).

So, a `load:start` fires on all loads (local or remote via `Backbone.sync`) but `load:end` only fires for remote syncs.

 This leaves me in permanent `loading` limbo on my local syncs!

Any ideas of a workaround here?
