### PR TITLE
Return view in existing case from _addChild.

### DIFF
--- a/src/thorax.js
+++ b/src/thorax.js
@@ -88,7 +88,7 @@ Thorax.View = Backbone.View.extend({
 
   _addChild: function(view) {
     if (this.children[view.cid]) {
-      return;
+      return view;
     }
     view.retain();
     this.children[view.cid] = view;


### PR DESCRIPTION
This small change allows `_addChild` to be called in the following manner for Thorax views:

``` javascript
this.newView = this._addChild(new AView());
this.oldView = this._addChild(aPreexistingView);
```

And, it normalizes the return value expectations to always provide the view.

/cc @eastridge 
