### PR TITLE
Add support for data-no-tap-highlight attribute

### DIFF
--- a/src/mobile/tap-highlight.js
+++ b/src/mobile/tap-highlight.js
@@ -21,6 +21,10 @@ $.fn.tapHoldAndEnd = function(selector, callbackStart, callbackEnd) {
     }
 
     $(this).on('touchstart', selector, function(event) {
+        if ($(event.currentTarget).attr('data-no-tap-highlight')) {
+          return;
+        }
+
         clearTapTimer();
 
         target = event.currentTarget;


### PR DESCRIPTION
Allows to turn off tap highlight behavior for selected elements, for example banner carousel where tap highlight may interfere with dragging (observing this on old androids). 
