### PR TITLE
Remove `data-submit-wait` attr from view el when resetting submit state

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -278,6 +278,7 @@ function objectAndKeyFromAttributesAndName(attributes, name, options, callback) 
 
 function resetSubmitState() {
   this.$('form').removeAttr('data-submit-wait');
+  this.$el.removeAttr('data-submit-wait');
 }
 
 function populateOptions(view) {


### PR DESCRIPTION
This allows the submission prevention to operate correctly when the view's element is the form.

Fixes walmartlabs/thorax#322
