### PR TITLE
Add view({el}) lookup option

### DIFF
--- a/src/thorax.js
+++ b/src/thorax.js
@@ -383,5 +383,9 @@ $.fn.view = function(options) {
     selector += ':not([' + viewHelperAttributeName + '])';
   }
   var el = $(this).closest(selector);
-  return (el && viewsIndexedByCid[el.attr(viewCidAttributeName)]) || false;
+  if (el) {
+    return options.el ? el : viewsIndexedByCid[el.attr(viewCidAttributeName)];
+  } else {
+    return false;
+  }
 };


### PR DESCRIPTION
Provides a slightly optimized path for cases where only the parent element is needed for $.view.
