### PR TITLE
`detach` instead of `remove` old view in `LayoutView setView`

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -30,7 +30,7 @@ Thorax.LayoutView = Thorax.View.extend({
 
     remove = _.bind(function() {
       if (oldView) {
-        oldView.$el && oldView.$el.remove();
+        oldView.$el && oldView.$el.detach();
         triggerLifecycleEvent.call(oldView, 'deactivated', options);
         this._removeChild(oldView);
       }


### PR DESCRIPTION
`$el.remove` also unbinds all events bound to the element, which is bad
when we're retaining the content view for reuse. This does not affect
views that expect the current behaviour of removing the element when
destroying, as that is still done by `_removeChild` if the retain count
of the view being removed is 0.

https://github.com/walmartlabs/thorax/issues/332
