### PR TITLE
Do not activate push state links if meta or shift are clicked.

### DIFF
--- a/src/thorax.js
+++ b/src/thorax.js
@@ -324,6 +324,12 @@ Thorax.View = Backbone.View.extend({
   _anchorClick: function(event) {
     var target = $(event.currentTarget),
         href = target.attr('href');
+
+    // Don't push if meta or shift key are clicked
+    if (event.metaKey || event.shiftKey) {
+      return true;
+    }
+
     // Route anything that starts with # or / (excluding //domain urls)
     if (href && (href[0] === '#' || (href[0] === '/' && href[1] !== '/'))) {
       Backbone.history.navigate(href, {

--- a/test/src/helpers/button-link.js
+++ b/test/src/helpers/button-link.js
@@ -91,4 +91,20 @@ describe('button-link helpers', function() {
     view.$el.remove();
     $(document).off('click.test.prevent-default');
   });
+
+  it("does not invoke Backbone.Navigate if when shift or meta keys are pressed on {{#links}}", function() {
+    var spy = sinon.spy(Backbone.history, 'navigate');
+
+    var view = new Thorax.View({
+      template: Handlebars.compile("{{#link '#test'}}Link{{/link}}")
+    });
+    var el = view.$('a').get(0);
+
+    view._anchorClick({ metaKey: true,  currentTarget: el });
+    view._anchorClick({ shiftKey: true, currentTarget: el });
+
+    expect(spy.called).to.equal(false);
+
+    spy.restore();
+  });
 });


### PR DESCRIPTION
When using the `{{#link}}` handlebars helper, right clicks and clicks using meta/shift keys do not follow traditional browser behavior. I took a look at [how AirBnB's Rendr is handling this](https://github.com/rendrjs/rendr/blob/master/client/app_view.js#L50-L60), and placed similar checks in the `_anchorClicked` view method. 

Unfortunately, my change isn't quite as robust as I would like. Right clicking still triggers `pushState`, and I cant ctrl+click on OSX to utilize the context menu, however it at least gets things to the point where I can open up links in a new window/tab if so desired.
