### PR TITLE
Emit non-server views on setView

### DIFF
--- a/test/src/event.js
+++ b/test/src/event.js
@@ -285,6 +285,7 @@ describe('event', function() {
     var spy = this.spy(),
         layoutView = new Thorax.LayoutView(),
         view = new Thorax.View({
+          serverRender: true,
           events: {
             ready: spy
           },
@@ -300,6 +301,7 @@ describe('event', function() {
     var spy = this.spy(),
         layoutView = new Thorax.LayoutView(),
         view = new Thorax.View({
+          serverRender: true,
           child: new Thorax.View({
             template: function() {},
             events: {

--- a/test/src/server-side.js
+++ b/test/src/server-side.js
@@ -1,4 +1,38 @@
 describe('serverSide', function() {
+  var _serverSide = window.$serverSide,
+      emit;
+  beforeEach(function() {
+    window.$serverSide = true;
+    window.emit = emit = this.spy();
+  });
+  afterEach(function() {
+    window.$serverSide = _serverSide;
+  });
+
+  describe('emit', function() {
+    it('should emit on setView for non-server views', function() {
+      var view = new Thorax.View(),
+          layout = new Thorax.LayoutView();
+
+      layout.setView(view);
+      expect(emit.calledOnce).to.be(true);
+    });
+    it('should defer emit for server-side views', function() {
+      var view = new Thorax.View({template: function() { return 'bar'; }}),
+          layout = new Thorax.LayoutView();
+
+      layout.setView(view, {serverRender: true});
+      expect(emit.called).to.be(false);
+
+      view = new Thorax.View({
+        serverRender: true,
+        template: function() { return 'bar'; }
+      });
+      layout.setView(view);
+      expect(emit.called).to.be(false);
+    });
+  });
+
   describe('events', function() {
     it('should NOP DOM events in server mode', function() {
       var spy = this.spy();


### PR DESCRIPTION
Provides default early emit behavior for views that are not flagged with the serverRender flag.

This allows for views to opt in to server side rendering. Those that are not set will run all router commands, inlining any loaded data responses at the time of the setView call.
