### PR TITLE
Add restore collection events

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -150,6 +150,8 @@ Thorax.CollectionView = Thorax.View.extend({
         }
       });
     }
+
+    this.trigger('restore:collection', this, el);
   },
 
   //appendItem(model [,index])
@@ -320,6 +322,9 @@ Thorax.CollectionView = Thorax.View.extend({
 
     child.restore(el);
     this._addChild(child);
+
+    this.trigger('restore:empty', this, el);
+
     return child;
   },
 
@@ -368,6 +373,8 @@ Thorax.CollectionView = Thorax.View.extend({
         this._addChild(child);
       }
     }
+
+    this.trigger('restore:item', this, el);
   },
   itemContext: function(model /*, i */) {
     return model.attributes;

--- a/src/helpers/collection.js
+++ b/src/helpers/collection.js
@@ -8,9 +8,12 @@
 Thorax.CollectionHelperView = Thorax.CollectionView.extend({
   // Forward render events to the parent
   events: {
-    'rendered:item': forwardRenderEvent('rendered:item'),
     'rendered:collection': forwardRenderEvent('rendered:collection'),
-    'rendered:empty': forwardRenderEvent('rendered:empty')
+    'rendered:item': forwardRenderEvent('rendered:item'),
+    'rendered:empty': forwardRenderEvent('rendered:empty'),
+    'restore:collection': forwardRenderEvent('restore:collection'),
+    'restore:item': forwardRenderEvent('restore:item'),
+    'restore:empty': forwardRenderEvent('restore:empty')
   },
 
   // Thorax.CollectionView allows a collectionSelector


### PR DESCRIPTION
Adds parity with the rendered collection events already available in the API.
