### PR TITLE
Use `instanceof` to detect jQuery objects

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-/*global createRegistryWrapper:true, getEventCallback */
+/*global createRegistryWrapper:true, getEventCallback, jQuery */
 
 function createErrorMessage(code) {
   return 'Error "' + code + '". For more information visit http://thoraxjs.org/error-codes.html' + '#' + code;


### PR DESCRIPTION
This should be more reliable than looking at properties of the object.

> the jQuery function (aka $) is implemented as a constructor function. Constructor functions are to be called with the new prefix.
> 
> When you call $(foo), internally jQuery translates this to new jQuery(foo)1. JavaScript proceeds to initialize this inside the constructor function to point to a new instance of jQuery, setting it's properties to those found on jQuery.prototype (aka jQuery.fn). Thus, you get a new object where instanceof jQuery is true.

From: http://stackoverflow.com/questions/1853223/check-if-object-is-a-jquery-object/1853246#1853246
