### PR TITLE
Support for filter event (CollectionViewHelper)

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -33,9 +33,9 @@ Thorax.Collection = Backbone.Collection.extend({
   fetch: function(options) {
     options = options || {};
     var success = options.success;
-    options.success = function(collection, response) {
+    options.success = function(collection, response, options) {
       collection._fetched = true;
-      success && success(collection, response);
+      success && success(collection, response, options);
     };
     return _fetch.apply(this, arguments);
   },


### PR DESCRIPTION
According to the documentation (http://thoraxjs.org/api.html) it should be possible to trigger the filter event on a collection to enforce a refilter of a collection bound to a CollectionViewHelper (with an itemFilter).

Added handling of the filter event of a collection bound to a CollectionViewHelper
