### PR TITLE
set checked attr to `true` rather than "checked"

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -133,7 +133,7 @@ _.extend(Thorax.View.prototype, {
           var isBinary = type === 'checkbox' || type === 'radio';
           if (isBinary) {
             value = _.isBoolean(value) ? value : value === $element.val();
-            $element[value ? 'attr' : 'removeAttr']('checked', 'checked');
+            $element[value ? 'attr' : 'removeAttr'](true, 'checked');
           } else {
             $element.val(value);
           }


### PR DESCRIPTION
setting an element to checked="checked", and then `removeAttr("checked")`
from that element results in the dom attribute of the element (as opposed to
the `checked` value of its IDL) being updated.

As a result, `$element.attr('checked')` that has run through this code will end
up being either `true` or `"checked"`.
