### PR TITLE
set checked attr to `true` rather than "checked"

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -133,7 +133,7 @@ _.extend(Thorax.View.prototype, {
           var isBinary = type === 'checkbox' || type === 'radio';
           if (isBinary) {
             value = _.isBoolean(value) ? value : value === $element.val();
-            $element[value ? 'attr' : 'removeAttr']('checked', 'checked');
+            $element.prop('checked', value);
           } else {
             $element.val(value);
           }


### PR DESCRIPTION
[from zepto](http://zeptojs.com/#prop)

"This should be preferred over attr in case of reading values of properties that change with user interaction over time, such as checked and selected."
