### PR TITLE
Add as a child before calling ensureRender in CollectionView#appendItem

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -199,8 +199,8 @@ Thorax.CollectionView = Thorax.View.extend({
 
     if (itemView) {
       if (itemView.cid) {
-        itemView.ensureRendered();
         this._addChild(itemView);
+        itemView.ensureRendered();
       }
 
       //if the renderer's output wasn't contained in a tag, wrap it in a div


### PR DESCRIPTION
This allows `this.parent` to be available during `render` of the child item view.

This solves an issue for me where I need to access properties on the parent view in `rendered` callbacks in the item view.
