### PR TITLE
Isolate fetchQueue instances

### DIFF
--- a/src/loading.js
+++ b/src/loading.js
@@ -385,12 +385,9 @@ function fetchQueue(options, $super) {
   var deferred;
   if ($.Deferred) {
     deferred = $.Deferred();
-    this.fetchQueue._promise.then(function() {
-        deferred.resolve.apply(deferred, arguments);
-      },
-      function() {
-        deferred.reject.apply(deferred, arguments);
-      });
+    this.fetchQueue._promise.then(
+        _.bind(deferred.resolve, deferred),
+        _.bind(deferred.reject, deferred));
   }
 
   var fetchQueue = this.fetchQueue;

--- a/test/src/loading.js
+++ b/test/src/loading.js
@@ -96,6 +96,39 @@ describe('loading', function() {
   
         server.restore();
       });
+
+      it("returns a promise and errors", function() {
+        var server = sinon.fakeServer.create();
+        var collection = new (Thorax.Collection.extend({
+          url: '/test'
+        }))();
+
+        function successHandler() {
+          throw new Error('Success called');
+        }
+        var errorSpy = this.spy();
+
+        var promise1 = collection.fetch();
+        promise1.then(successHandler, errorSpy);
+
+        var promise2 = collection.fetch();
+        promise2.then(successHandler, errorSpy);
+
+        expect(promise1).to.not.equal(promise2);
+        expect(server.requests.length).to.equal(1);
+
+        server.requests[0].respond(404, {
+          "Content-Type": "application/json"
+        }, JSON.stringify([{
+          id: 1,
+          text: "test"
+        }]));
+
+        expect(errorSpy.callCount).to.equal(2);
+        expect(errorSpy.args[0][1]).to.equal('error');
+  
+        server.restore();
+      });
     }
   });
 


### PR DESCRIPTION
Previously we were aborting the upstream request if any pending calls
triggered a bindToRoute cleanup. This caused issues when fetch+load calls were
made on a single object as the load call would terminate the fetch call
incorrectly.
