### PR TITLE
The "itemView" property can now take a function.

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -350,7 +350,7 @@ Thorax.CollectionView = Thorax.View.extend({
       if (this.emptyTemplate) {
         viewOptions.template = this.emptyTemplate;
       }
-      return Thorax.Util.getViewInstance(this.emptyView, viewOptions);
+      return Thorax.Util.getViewInstance.call(this, this.emptyView, viewOptions);
     } else {
       return this.emptyTemplate && this.renderTemplate(this.emptyTemplate);
     }
@@ -388,7 +388,7 @@ Thorax.CollectionView = Thorax.View.extend({
       if (this.itemTemplate) {
         viewOptions.template = this.itemTemplate;
       }
-      return Thorax.Util.getViewInstance(this.itemView, viewOptions);
+      return Thorax.Util.getViewInstance.call(this, this.itemView, viewOptions);
     } else {
       // Using call here to avoid v8 prototype inline optimization bug that helper views
       // expose under Android 4.3 (at minimum)

--- a/src/loading.js
+++ b/src/loading.js
@@ -369,7 +369,7 @@ function fetchQueue(options, $super) {
       var promise = $super.call(this, requestOptions);
       if (this.fetchQueue) {
         // ensure the fetchQueue has not been cleared out - https://github.com/walmartlabs/thorax/issues/304
-        // This can occur in some environments if the request fails sync to this call, causing the 
+        // This can occur in some environments if the request fails sync to this call, causing the
         // error handler to clear out the fetchQueue before we get to this point.
         this.fetchQueue._promise = promise;
       } else {
@@ -528,7 +528,7 @@ inheritVars.collection.loading = function() {
         this.$el.empty();
       }
       if (loadingView) {
-        var instance = Thorax.Util.getViewInstance(loadingView);
+        var instance = Thorax.Util.getViewInstance.call(this, loadingView);
         this._addChild(instance);
         if (loadingTemplate) {
           instance.render(loadingTemplate);

--- a/src/util.js
+++ b/src/util.js
@@ -251,7 +251,15 @@ function filterAncestors(parent, callback) {
 Thorax.Util = {
   getViewInstance: function(name, attributes) {
     var ViewClass = Thorax.Util.getViewClass(name, true);
-    return ViewClass ? new ViewClass(attributes || {}) : name;
+    if (ViewClass === false) {
+      return name;
+    } else {
+      if (ViewClass.prototype instanceof Thorax.View) {
+        return new ViewClass(attributes || {});
+      } else {
+        return ViewClass.call(this, attributes || { });
+      }
+    }
   },
 
   getViewClass: function(name, ignoreErrors) {


### PR DESCRIPTION
_NB_: Tests need to be written for this yet.

Normally the `itemView` property of a `Thorax.CollectionView` expects either a string or a `Thorax.View` constructor. We just tweak the checks in `getViewInstance` to be smarter about detecting whether the function is a constructor of a `Thorax.View` or not; if it is a constructor it behaves just as before, and if not we attempt to invoke it as a method of the parent view (by passing `this` through).
