### PR TITLE
Utilize lodash for server builds

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "jquery": "1.9.x",
     "underscore": "1.4.4",
+    "lodash": "2.4.1",
     "zepto": "1.1.3",
     "handlebars": "2.x",
     "backbone": "1.1.0"

--- a/build.json
+++ b/build.json
@@ -17,7 +17,7 @@
     },
     "fruit-loops": {
       "scripts": [
-        {"src": "underscore.js", "bower": "underscore", "global": true, "ignoreWarnings": true},
+        {"src": "dist/lodash.underscore.js", "bower": "lodash", "global": true, "ignoreWarnings": true},
         {"src": "backbone.js", "bower": "backbone", "global": true, "ignoreWarnings": true},
         {"src": "handlebars.js", "bower": "handlebars", "global": true, "ignoreWarnings": true}
       ]

--- a/lumbar.json
+++ b/lumbar.json
@@ -5,7 +5,8 @@
     "thorax-dep-jquery": {
       "scripts": [
         {"src": "jquery.js", "bower": "jquery", "global": true, "ignoreWarnings": true, "server": false},
-        {"src": "underscore.js", "bower": "underscore", "global": true, "ignoreWarnings": true},
+        {"src": "underscore.js", "bower": "underscore", "global": true, "ignoreWarnings": true, "server": false},
+        {"src": "dist/lodash.underscore.js", "bower": "lodash", "global": true, "ignoreWarnings": true, "server": true},
         {"src": "backbone.js", "bower": "backbone", "global": true, "ignoreWarnings": true},
         {"src": "handlebars.js", "bower": "handlebars", "global": true, "ignoreWarnings": true},
       ]
@@ -13,7 +14,8 @@
     "thorax-dep-zepto": {
       "scripts": [
         {"src": "zepto.js", "bower": "zepto", "global": true, "ignoreWarnings": true, "server": false},
-        {"src": "underscore.js", "bower": "underscore", "global": true, "ignoreWarnings": true},
+        {"src": "underscore.js", "bower": "underscore", "global": true, "ignoreWarnings": true, "server": false},
+        {"src": "dist/lodash.underscore.js", "bower": "lodash", "global": true, "ignoreWarnings": true, "server": true},
         {"src": "backbone.js", "bower": "backbone", "global": true, "ignoreWarnings": true},
         {"src": "handlebars.runtime.js", "bower": "handlebars", "global": true, "ignoreWarnings": true},
       ]


### PR DESCRIPTION
Provides a speed boost for raw throughput. Only utilizing this in server builds as we are willing to trade build size for throughput in server side builds but we do not want to do this for client-side builds.
