### PR TITLE
Success handler of fetch is not called when response is synchronous (and fetchQueue is empty)

### DIFF
--- a/src/loading.js
+++ b/src/loading.js
@@ -392,7 +392,7 @@ function fetchQueue(dataObj, options, $super) {
 
   var fetchQueue = dataObj.fetchQueue;
   dataObj.fetchQueue.push({
-    // Individual requests can only fail individually. Success willl always occur via the
+    // Individual requests can only fail individually. Success will always occur via the
     // normal xhr path
     aborted: function() {
       var index = _.indexOf(fetchQueue, this);

--- a/test/src/loading.js
+++ b/test/src/loading.js
@@ -68,6 +68,24 @@ describe('loading', function() {
       expect(endSpy.callCount).to.equal(0);
     });
 
+
+    it("calls the success handler on the first fetch call when the fetch operation is synchronous", function () {
+      var collection = new (Thorax.Collection.extend({
+        url: "test"
+      }));
+
+      var syncStub = sinon.stub(Backbone, "sync", function (method, model, options) {
+        options.success(model, [ { name: "Test", value: "Value" } ], options)
+      });
+
+      var successSpy = sinon.spy();
+
+      collection.fetch({ success: successSpy });
+      syncStub.restore();
+
+      expect(successSpy.callCount).to.equal(1);
+    });
+
     // for jQuery or Zepto when built with Deferred
     if ($.when) {
       it("returns a promise", function() {


### PR DESCRIPTION
In the fetchQueue method a new queue is created when no one exists. Additionally the success and error callbacks are overridden to point to flushQueue. When super ($super.call) is called, the fetch queue is still empty. When the super.call now resolves the success handler synchronous (no defer or anything), then at the moment where flushQueue is called, the queue is still empty, and the success or error handler are not called (because the queue is empty)

A simple solution could be, that super will be invoked using _.defer. Otherwise the registration in the flushQueue must take place before invoking super... 
