### PR TITLE
Use parent() to get  itemView parent on itemFilter, fixes #412

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -556,7 +556,7 @@ function applyItemVisiblityFilter(view, model) {
     var show = !!itemShouldBeVisible(view, model);
     $el.find('[' + modelCidAttributeName + '="' + model.cid + '"]').forEach(function(el) {
       var $el = $(el),
-          parentCid = $el.view({cid: true});
+          parentCid = $el.parent().attr(viewCidAttributeName);
       if (view.cid === parentCid) {
         $el.toggle(show);
       }

--- a/test/src/collection.js
+++ b/test/src/collection.js
@@ -341,6 +341,27 @@ describe('collection', function() {
       expect(view.$('div').eq(1).css('display')).to.not.equal('none');
     });
 
+    it("itemFilter will work when itemView is used", function() {
+      var view = new Thorax.View({
+        collection: new Thorax.Collection([
+          {letter: 'a'},
+          {letter: 'b'}
+        ]),
+        itemView: Thorax.View.extend({
+          tagName: 'li',
+          template: Handlebars.compile('{{letter}}')
+        }),
+        template: Handlebars.compile('{{collection tag="ul" item-view=itemView}}'),
+        itemFilter: function(model) {
+          return model.get('letter') !== 'a';
+        }
+      });
+      view.render();
+
+      expect(view.$('li').eq(0).css('display')).to.equal('none');
+      expect(view.$('li').eq(1).css('display')).to.not.equal('none');
+    });
+
     it('will re-render on updateFilter call', function() {
       var view = new Thorax.CollectionView({
         collection: new Thorax.Collection([


### PR DESCRIPTION
This was done to fix #412. I added a test case that failed before this fix.