### PR TITLE
Bug: IE8 loadInfo Event is null

### DIFF
--- a/src/loading.js
+++ b/src/loading.js
@@ -70,7 +70,7 @@ Thorax.loadHandler = function(start, end, context) {
 
     loadInfo.events.push(object);
 
-    object.on(loadEnd, function endCallback() {
+    $(object).on(loadEnd, function endCallback() {
       var loadingEndTimeout = self._loadingTimeoutEndDuration;
       if (loadingEndTimeout === void 0) {
         // If we are running on a non-view object pull the default timeout


### PR DESCRIPTION
This PR fixes a bug in IE 8 where loadEvent is not available in the `object.on` handler in the loadHandler after a render is already done. This JS bin demonstrates the issue:http://jsfiddle.net/wLc8e7fn/1/  If you open the the bin in IE 8 (https://jsfiddle.net/wLc8e7fn/1/embedded/result/) and try to add a new name to the Heros list, it will give you the following error: `'loadInfo.events' is null or not an object`